### PR TITLE
Add padding to #words to remove text overlap

### DIFF
--- a/style.css
+++ b/style.css
@@ -100,7 +100,7 @@ body {
 
 /* Styles for the container element with id 'words' */
 #words {
-    height: 7.2rem;  
+    padding: 10px 0;
 }
 
 /* Button CSS styles */


### PR DESCRIPTION
Removed the height of 7.2rem and replaced with padding of 10px top and bottom to fix the text overlap.